### PR TITLE
Implemented `address-validator` component.

### DIFF
--- a/src/app/modules/core/components/address-validator/address-validator.component.html
+++ b/src/app/modules/core/components/address-validator/address-validator.component.html
@@ -1,6 +1,6 @@
 
 <label for="address-validator_{{label}}" class='text-nowrap'>{{label}}
-  <span class="geocoder-status">
+  <span class="address-validator-status">
     <ng-container *ngIf="isTypeaheadLoading; else statusContainer"> &mdash; Loading
       <i class="fa fa-spinner fa-pulse fa-fw"></i>
     </ng-container>

--- a/src/app/modules/core/components/address-validator/address-validator.component.html
+++ b/src/app/modules/core/components/address-validator/address-validator.component.html
@@ -1,0 +1,52 @@
+
+<label for="address-validator_{{label}}" class='text-nowrap'>{{label}}
+  <span class="geocoder-status">
+    <ng-container *ngIf="isTypeaheadLoading; else statusContainer"> &mdash; Loading
+      <i class="fa fa-spinner fa-pulse fa-fw"></i>
+    </ng-container>
+  </span>
+
+  <ng-template #statusContainer>
+    <ng-template *ngIf="selectedAddress; then addressSelected; else error;"></ng-template>
+  </ng-template>
+</label>
+<input class="form-control"
+       type="text"
+       id="address-validator_{{label}}"
+       name="address-validator_{{label}}"
+       [(ngModel)]='search'
+       (keyup)='onKeyUp($event)'
+       [typeahead]='typeaheadList$'
+       [typeaheadIsFirstItemActive]="false"
+       [typeaheadSelectFirstItem]="false"
+       (typeaheadLoading)="onLoading($event)"
+       (typeaheadOnSelect)="onSelect($event)"
+       (typeaheadNoResults)="onNoResults($event)"
+       (blur)="onBlur($event)"
+       [attr.maxlength]='maxlength'
+       typeaheadOptionField='AddressComplete'
+       typeaheadMinLength='3'
+       autocomplete="off"
+       spellcheck="false"
+        />
+        <!-- Intentionally using 'nope' for autocomplete as it is invalid and forces false - https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion -->
+
+
+<ng-template #addressSelected>
+    <span> &mdash; Selected
+        <i class="fa fa-check fa-fw text-success"></i>
+    </span>
+</ng-template>
+
+<ng-template #noResults>
+    <span *ngIf="hasNoResults"> &mdash; No Results
+        <i class="fa fa-times fa-fw text-warning"></i>
+    </span>
+</ng-template>
+
+
+<ng-template #error>
+    <span *ngIf='hasError; else noResults'> &mdash; Error
+        <i class="fa fa-exclamation-triangle fa-fw text-danger"></i>
+    </span>
+</ng-template>

--- a/src/app/modules/core/components/address-validator/address-validator.component.spec.ts
+++ b/src/app/modules/core/components/address-validator/address-validator.component.spec.ts
@@ -5,7 +5,6 @@ import { FormsModule } from '@angular/forms';
 import { TypeaheadModule } from 'ngx-bootstrap';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
-import { GeocoderService } from 'moh-common-lib/services';
 import { Address } from 'moh-common-lib/models';
 
 
@@ -13,10 +12,7 @@ describe('AddressValidatorComponent', () => {
   let component: AddressValidatorComponent;
   let fixture: ComponentFixture<AddressValidatorComponent>;
 
-  let lookupSpy;
-  let geoService;
-
-  // The result when user searches '784 y' - after GeocoderService has processed it
+  // The result when user searches '784 y'.
   const yatesResponse = [
     {fullAddress: '784 Yates St, Victoria, BC', city: 'Victoria', street: '784 Yates St', country: 'Canada', province: 'British Columbia'},
     {fullAddress: '784 Young Rd, Kelowna, BC', city: 'Kelowna', street: '784 Young Rd', country: 'Canada', province: 'British Columbia'}
@@ -24,15 +20,13 @@ describe('AddressValidatorComponent', () => {
 
   beforeEach(async(() => {
 
-    geoService = jasmine.createSpyObj('GeocoderService', ['lookup']);
-    lookupSpy = geoService.lookup.and.returnValue( of(yatesResponse) );
-
     TestBed.configureTestingModule({
       declarations: [ AddressValidatorComponent ],
-      providers: [
-        {provide: GeocoderService, useValue: geoService}
-      ],
-      imports: [ FormsModule, TypeaheadModule.forRoot(), HttpClientTestingModule ]
+      imports: [
+        FormsModule,
+        TypeaheadModule.forRoot(),
+        HttpClientTestingModule
+      ]
     })
     .compileComponents();
   }));
@@ -48,10 +42,6 @@ describe('AddressValidatorComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should not call GeocoderService.lookup() after initialization', () => {
-    expect(lookupSpy.calls.any()).toBe(false, 'GeoCoderService.lookup() should not be called on component load');
-  });
-
   it('should emit an address when one is selected from typeahead', fakeAsync(() => {
     let typeaheadMatch: any;
     component.typeaheadList$.subscribe(x => {
@@ -64,7 +54,6 @@ describe('AddressValidatorComponent', () => {
     component.addressChange.subscribe((address: Address) => {
       expect(address).toBeDefined('Address should be emitted after calling component.onSelect()');
       // tslint:disable-next-line: max-line-length
-      // expect(address._geocoderFullAddress).toBe(typeaheadMatch.item.fullAddress, 'Address _geocoderFullAddress should equal typeahead match ');
       expect(address.street).toBe(typeaheadMatch.item.street, 'Address street should match typeahead value');
       expect(address.city).toBe(typeaheadMatch.item.city, 'Address city should match typeahead value');
       expect(address.province).toBe(typeaheadMatch.item.province, 'Address province should match typeahead value');
@@ -90,7 +79,7 @@ describe('AddressValidatorComponent', () => {
     expect(component.hasNoResults).toBe(true);
 
     // Check UI
-    const el = fixture.nativeElement.querySelector('.geocoder-status');
+    const el = fixture.nativeElement.querySelector('.address-validator-status');
     fixture.detectChanges();
     expect(el.textContent).toContain('No Results', '"No Results" text should be displayed to user');
   });

--- a/src/app/modules/core/components/address-validator/address-validator.component.spec.ts
+++ b/src/app/modules/core/components/address-validator/address-validator.component.spec.ts
@@ -1,0 +1,97 @@
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+
+import { AddressValidatorComponent } from './address-validator.component';
+import { FormsModule } from '@angular/forms';
+import { TypeaheadModule } from 'ngx-bootstrap';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { GeocoderService } from 'moh-common-lib/services';
+import { Address } from 'moh-common-lib/models';
+
+
+describe('AddressValidatorComponent', () => {
+  let component: AddressValidatorComponent;
+  let fixture: ComponentFixture<AddressValidatorComponent>;
+
+  let lookupSpy;
+  let geoService;
+
+  // The result when user searches '784 y' - after GeocoderService has processed it
+  const yatesResponse = [
+    {fullAddress: '784 Yates St, Victoria, BC', city: 'Victoria', street: '784 Yates St', country: 'Canada', province: 'British Columbia'},
+    {fullAddress: '784 Young Rd, Kelowna, BC', city: 'Kelowna', street: '784 Young Rd', country: 'Canada', province: 'British Columbia'}
+  ];
+
+  beforeEach(async(() => {
+
+    geoService = jasmine.createSpyObj('GeocoderService', ['lookup']);
+    lookupSpy = geoService.lookup.and.returnValue( of(yatesResponse) );
+
+    TestBed.configureTestingModule({
+      declarations: [ AddressValidatorComponent ],
+      providers: [
+        {provide: GeocoderService, useValue: geoService}
+      ],
+      imports: [ FormsModule, TypeaheadModule.forRoot(), HttpClientTestingModule ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddressValidatorComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not call GeocoderService.lookup() after initialization', () => {
+    expect(lookupSpy.calls.any()).toBe(false, 'GeoCoderService.lookup() should not be called on component load');
+  });
+
+  it('should emit an address when one is selected from typeahead', fakeAsync(() => {
+    let typeaheadMatch: any;
+    component.typeaheadList$.subscribe(x => {
+      typeaheadMatch = { item: x[0] };
+      // Simulate user has selected the first typeahead item (i.e. enter/tab/clicked on first item)
+      component.onSelect(typeaheadMatch);
+    });
+
+    // Check for @Output emit, triggered via the .onSelect() above
+    component.addressChange.subscribe((address: Address) => {
+      expect(address).toBeDefined('Address should be emitted after calling component.onSelect()');
+      // tslint:disable-next-line: max-line-length
+      // expect(address._geocoderFullAddress).toBe(typeaheadMatch.item.fullAddress, 'Address _geocoderFullAddress should equal typeahead match ');
+      expect(address.street).toBe(typeaheadMatch.item.street, 'Address street should match typeahead value');
+      expect(address.city).toBe(typeaheadMatch.item.city, 'Address city should match typeahead value');
+      expect(address.province).toBe(typeaheadMatch.item.province, 'Address province should match typeahead value');
+      expect(address.country).toBe(typeaheadMatch.item.country, 'Address country should match typeahead value');
+    });
+
+    // Now that listeners are setup, trigger the user input and kick if off
+    component.search = '784 y';
+    const keyEvent = new KeyboardEvent('keyup');
+    component.onKeyUp(keyEvent);
+    tick(500); // same as debounceTime()
+  }));
+
+  it('should properly show when no results', () => {
+    // This is not testing the typeaheadNoResults directive since it's a 3rd
+    // party dep, but rather that the method it calls properly updates when
+    // passed a boolean
+
+    // Check data
+    component.search = 'example';
+    fixture.detectChanges();
+    component.onNoResults(true);
+    expect(component.hasNoResults).toBe(true);
+
+    // Check UI
+    const el = fixture.nativeElement.querySelector('.geocoder-status');
+    fixture.detectChanges();
+    expect(el.textContent).toContain('No Results', '"No Results" text should be displayed to user');
+  });
+});

--- a/src/app/modules/core/components/address-validator/address-validator.component.ts
+++ b/src/app/modules/core/components/address-validator/address-validator.component.ts
@@ -98,7 +98,7 @@ export class AddressValidatorComponent extends Base implements OnInit, ControlVa
   }
 
   onLoading(val: boolean): void {
-    // console.log( 'onLoading - geocoder' , val );
+    // console.log( 'onLoading - address-validator' , val );
     this.isTypeaheadLoading = val;
     this.hasError = false;
   }
@@ -216,8 +216,8 @@ export class AddressValidatorComponent extends Base implements OnInit, ControlVa
   }
 
   protected handleError(error: HttpErrorResponse) {
-    console.error('GeoCoder network error', { error });
-    return throwError('Geocoder error');
+    console.error('AddressValidator network error', { error });
+    return throwError('AddressValidator error');
   }
 
 }

--- a/src/app/modules/core/components/address-validator/address-validator.component.ts
+++ b/src/app/modules/core/components/address-validator/address-validator.component.ts
@@ -1,0 +1,223 @@
+import { Component, OnInit, Input, ChangeDetectorRef, Output, EventEmitter, SimpleChanges, OnChanges, Optional, Self } from '@angular/core';
+import { Subject, Observable, of, throwError } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap, map, catchError } from 'rxjs/operators';
+import { TypeaheadMatch } from 'ngx-bootstrap';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { Base, Address } from 'moh-common-lib/models';
+import { NgControl, ControlValueAccessor } from '@angular/forms';
+import { environment } from 'environments/environment';
+
+
+/**
+ * For TemplateForms, pass in an Address and recieve an Address
+ * @example
+ *           <common-address-validator
+ *               label='Physical Address'
+ *               [(ngModel)]="myAddress">
+ *           </common-address-validator>
+ *
+ * @note
+ * For ReactiveForms, pass in a string and recieve a string.  If you need the
+ * Address object you can use (select) in addition.
+ *
+ * @example
+ *           <common-address-validator
+ *              label='Physical Address'
+ *              formControlName="address"
+ *              (select)="getAddressObject($event)">
+ *          </common-address-validator>
+ */
+
+export interface GeoAddressResult {
+  /** String from the API that includes street, city, province, and country. */
+  AddressComplete: string;
+  Locality: string;
+  DeliveryAddressLines: string;
+  // Set to defaults in response
+  Country: string;
+  Province: string;
+  PostalCode: string;
+}
+
+@Component({
+  selector: 'common-address-validator',
+  templateUrl: './address-validator.component.html',
+  styleUrls: ['./address-validator.component.scss']
+})
+export class AddressValidatorComponent extends Base implements OnInit, ControlValueAccessor {
+
+  @Input() label: string = 'Address Lookup';
+  @Input() address: string;
+  @Input() serviceUrl: string = environment.addressUrl;
+  @Output() addressChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() select: EventEmitter<Address> = new EventEmitter<Address>();
+
+  @Input() maxlength: string = '255';
+
+  /** The string in the box the user has typed */
+  public search: string;
+  /** Is the request still in progress? */
+  public isTypeaheadLoading: boolean = false;
+  /** has returned and has no results, an empty array. */
+  public hasNoResults: boolean = false;
+  public hasError: boolean = false;
+
+  /** Similar to this.address, but we can null it when user is searching for new addresses */
+  public selectedAddress: boolean = false;
+  /** The list of results, from API, that is passed to the typeahead list */
+  public typeaheadList$: Observable<GeoAddressResult[]>; // Result from address lookup
+  /** The subject that triggers on user text input and gets typeaheadList$ to update.  */
+  private searchText$ = new Subject<string>();
+
+  _onChange = (_: any) => {};
+  _onTouched = (_?: any) => {};
+
+  constructor(@Optional() @Self() public controlDir: NgControl,
+              private cd: ChangeDetectorRef,
+              protected http: HttpClient) {
+    super();
+    if ( controlDir ) {
+      controlDir.valueAccessor = this;
+    }
+  }
+
+  ngOnInit() {
+    this.typeaheadList$ = this.searchText$.pipe(
+      debounceTime(500),
+      distinctUntilChanged(),
+      // Trigger the network request, get results
+      switchMap(searchPhrase => this.lookup(searchPhrase)),
+      catchError(err => this.onError(err))
+    );
+  }
+
+  onError(err): Observable<GeoAddressResult[]> {
+    this.hasError = true;
+    // Empty array simulates no result response, nothing for typeahead to iterate over
+    return of([]);
+  }
+
+  onLoading(val: boolean): void {
+    // console.log( 'onLoading - geocoder' , val );
+    this.isTypeaheadLoading = val;
+    this.hasError = false;
+  }
+
+  // Note - this will fire after an onError as well
+  onNoResults(val: boolean): void {
+
+   //  console.log( 'No results - AddressValidator' , val );
+
+    // If we have results, the error has resolved (e.g. network has re-connected)
+    if (val === false) {
+      this.hasError = false;
+    }
+
+    this.hasNoResults = val;
+  }
+
+  onSelect(event: TypeaheadMatch): void {
+
+    // console.log( 'onSelect: ', event );
+    const data: GeoAddressResult = event.item;
+
+    // Output string to FormControl. If street is more than the max length shorten
+    const stripped = this.stripStringToMaxLength(data.DeliveryAddressLines);
+
+    const addr = new Address();
+    addr.city = data.Locality;
+    addr.country = data.Country;
+    addr.province = data.Province;
+    addr.street = stripped;
+    addr.postal = data.PostalCode;
+    // Save and emit Address for (select)
+    this.selectedAddress = true;
+    this.select.emit(addr);
+
+    this._onChange(stripped);
+  }
+
+  onKeyUp(event: KeyboardEvent): void {
+    // Filter out 'enter' and other similar keyboard events that can trigger
+    // when user is selecting a typeahead option instead of entering new text.
+    // Without this filter, we do another HTTP request + force disiplay the UI
+    // for now reason
+    if (event.keyCode === 13 || event.keyCode === 9) {  // enter & tab
+      return;
+    }
+    // Clear out selection
+    this.selectedAddress = false;
+    this.searchText$.next(this.search);
+  }
+
+  onBlur(event): void {
+    this._onTouched();
+    this._onChange(this.search);
+  }
+
+
+  writeValue( value: any ): void {
+    if ( value  !== undefined ) {
+      this.search = value;
+    }
+  }
+
+  // Register change function
+  registerOnChange( fn: any ): void {
+    this._onChange = fn;
+  }
+
+  // Register touched function
+  registerOnTouched( fn: any ): void {
+    this._onTouched = fn;
+  }
+
+  private stripStringToMaxLength(str: string) {
+    const maxlength = parseInt(this.maxlength, 10);
+    return str.slice(0, maxlength);
+  }
+
+  lookup(address: string): Observable<GeoAddressResult[]> {
+    const params = new HttpParams()
+                    .set('address', address);
+
+    return this.http.get(this.serviceUrl, {
+      params: params
+    }).pipe(map(this.processResponse));
+  }
+
+  /**
+   * Formats the response from ADDRESS_URL, trimming irrelevant fields.
+   *
+   * This works for other requests for the same API too, however it may error
+   * out on some items if matchPrecisionNot is not set.
+   *
+   * @param obj The response from ADDRESS_URL
+   */
+  protected processResponse(obj): GeoAddressResult[] {
+    return obj.Address.map(feature => {
+      const props = feature;
+      const Locality = props.Locality;
+      const AddressComplete = props.AddressComplete;
+      const DeliveryAddressLines = props.DeliveryAddressLines;
+      const Province = props.Province;
+      const Country = props.Country;
+      const PostalCode = props.PostalCode;
+
+      return {
+        AddressComplete,
+        Locality,
+        DeliveryAddressLines,
+        Province,
+        Country,
+        PostalCode
+      };
+    });
+  }
+
+  protected handleError(error: HttpErrorResponse) {
+    console.error('GeoCoder network error', { error });
+    return throwError('Geocoder error');
+  }
+
+}

--- a/src/app/modules/core/core.module.ts
+++ b/src/app/modules/core/core.module.ts
@@ -26,11 +26,14 @@ import { SinComponent } from './components/sin/sin.component';
 import {NameComponent} from './components/name/name.component';
 import { ModalFocusDirective } from './components/consent-modal/modal-focus.directive';
 import { PhnDefinitionComponent } from './components/phn-definition/phn-definition.component';
+import { AddressValidatorComponent } from './components/address-validator/address-validator.component';
 import { SampleModalComponent } from './components/sample-modal/sample-modal.component';
 import { CaptchaModule } from 'moh-common-lib/captcha';
 import { SharedCoreModule } from 'moh-common-lib';
+import { TypeaheadModule } from 'ngx-bootstrap';
 
 const componentList = [
+  AddressValidatorComponent,
   AlertComponent,
   FPCareToggleComponent,
   PhnComponent,
@@ -66,6 +69,7 @@ const componentList = [
     RouterModule,
     ModalModule.forRoot(),
     TextMaskModule,
+    TypeaheadModule,
     CaptchaModule,
     SharedCoreModule
   ],

--- a/src/app/modules/registration/pages/mailing-address/mailing-address.component.html
+++ b/src/app/modules/registration/pages/mailing-address/mailing-address.component.html
@@ -85,7 +85,7 @@
                  id="country"
                  name="country"
                  disabled
-                 [ngModel]="applicant.updAddress?.country" />
+                 [ngModel]="countryName" />
         </div>
       </div>
     </div>

--- a/src/app/modules/registration/pages/mailing-address/mailing-address.component.html
+++ b/src/app/modules/registration/pages/mailing-address/mailing-address.component.html
@@ -31,10 +31,15 @@
       </p>
       <div class="p-md-2 col-md-6">
         <div class="form-group">
-          <common-address-validator label='(optional) Address Lookup'
+          <common-address-validator *ngIf='isAddressValidatorEnabled'
+                                 label='(optional) Address Lookup'
                                  [(address)]='applicant.updAddress'
                                  (addressChange)='onGeoLookup()'
                                  (select)='onAddressSelected($event)'></common-address-validator>
+          <fpcare-geocoder-input *ngIf='!isAddressValidatorEnabled'
+                                 label='(optional) Address Lookup'
+                                 [(address)]='applicant.updAddress'
+                                 (addressChange)='onGeoLookup()'></fpcare-geocoder-input>
         </div>
         <div class="form-group">
           <label for="street">Street address, rural route or PO Box</label>

--- a/src/app/modules/registration/pages/mailing-address/mailing-address.component.html
+++ b/src/app/modules/registration/pages/mailing-address/mailing-address.component.html
@@ -31,9 +31,10 @@
       </p>
       <div class="p-md-2 col-md-6">
         <div class="form-group">
-          <fpcare-geocoder-input label='(optional) Address Lookup'
+          <common-address-validator label='(optional) Address Lookup'
                                  [(address)]='applicant.updAddress'
-                                 (addressChange)='onGeoLookup()'></fpcare-geocoder-input>
+                                 (addressChange)='onGeoLookup()'
+                                 (select)='onAddressSelected($event)'></common-address-validator>
         </div>
         <div class="form-group">
           <label for="street">Street address, rural route or PO Box</label>
@@ -84,7 +85,7 @@
                  id="country"
                  name="country"
                  disabled
-                 [ngModel]="countryName" />
+                 [ngModel]="applicant.updAddress?.country" />
         </div>
       </div>
     </div>

--- a/src/app/modules/registration/pages/mailing-address/mailing-address.component.ts
+++ b/src/app/modules/registration/pages/mailing-address/mailing-address.component.ts
@@ -68,7 +68,8 @@ export class MailingAddressPageComponent extends AbstractFormComponent implement
   }
 
   get countryName(): string {
-    return CountryNames[this.applicant.updAddress.country];
+    return CountryNames[this.applicant.updAddress.country]
+      || (this.applicant.updAddress && this.applicant.updAddress.country);
   }
 
   getProvinceID( index ) {
@@ -152,6 +153,8 @@ export class MailingAddressPageComponent extends AbstractFormComponent implement
       this.applicant.updAddress.postal = address.postal;
       this.applicant.updAddress.province = address.province;
       this.applicant.updAddress.country = address.country;
+
+      this.onGeoLookup();
     }
   }
 

--- a/src/app/modules/registration/pages/mailing-address/mailing-address.component.ts
+++ b/src/app/modules/registration/pages/mailing-address/mailing-address.component.ts
@@ -17,6 +17,7 @@ import {ValidationService} from '../../../../services/validation.service';
 import {PersonType} from '../../../../models/api.model';
 import {ResponseStoreService} from '../../../../services/response-store.service';
 import { Address } from 'moh-common-lib/models/public_api';
+import { SpaEnvService } from '../../../../services/spa-env.service';
 
 @Component({
   selector: 'fpcare-mailing-address',
@@ -37,7 +38,8 @@ export class MailingAddressPageComponent extends AbstractFormComponent implement
              , protected router: Router
              , private registrationService: RegistrationService
              , private responseStore: ResponseStoreService
-             , private cd: ChangeDetectorRef) {
+             , private cd: ChangeDetectorRef
+             , public spaEnvService: SpaEnvService) {
     super( router );
   }
 
@@ -172,6 +174,11 @@ export class MailingAddressPageComponent extends AbstractFormComponent implement
    */
   get streetMaxLength(): number {
     return ValidationService.MAX_STREET_LENGTH;
+  }
+
+  get isAddressValidatorEnabled(): boolean {
+    const envs = this.spaEnvService.getValues();
+    return envs && envs.SPA_ENV_FPC_ENABLE_ADDRESS_VALIDATOR === 'true';
   }
 
   /**

--- a/src/app/modules/registration/pages/mailing-address/mailing-address.component.ts
+++ b/src/app/modules/registration/pages/mailing-address/mailing-address.component.ts
@@ -16,6 +16,7 @@ import {
 import {ValidationService} from '../../../../services/validation.service';
 import {PersonType} from '../../../../models/api.model';
 import {ResponseStoreService} from '../../../../services/response-store.service';
+import { Address } from 'moh-common-lib/models/public_api';
 
 @Component({
   selector: 'fpcare-mailing-address',
@@ -137,6 +138,21 @@ export class MailingAddressPageComponent extends AbstractFormComponent implement
       this.fpcareRequired.map(x => x.runAll());
       this.cd.detectChanges();
     }, 0);
+  }
+
+  onAddressSelected(address: Address) {
+    if (address &&
+        address.street &&
+        address.city &&
+        address.postal &&
+        address.province &&
+        address.country) {
+      this.applicant.updAddress.street = address.street;
+      this.applicant.updAddress.city = address.city;
+      this.applicant.updAddress.postal = address.postal;
+      this.applicant.updAddress.province = address.province;
+      this.applicant.updAddress.country = address.country;
+    }
   }
 
   /**

--- a/src/app/services/spa-env.service.ts
+++ b/src/app/services/spa-env.service.ts
@@ -16,6 +16,7 @@ const serverEnvs = {
   SPA_ENV_FPC_MAINTENANCE_START: '',
   SPA_ENV_FPC_MAINTENANCE_END: '',
   SPA_ENV_FPC_MAINTENANCE_MESSAGE: '',
+  SPA_ENV_FPC_ENABLE_ADDRESS_VALIDATOR: '',
 };
 
 // Used in HTTP request
@@ -57,6 +58,10 @@ export class SpaEnvService extends AbstractHttpService {
     super(http);
 
     this.loadEnvs().subscribe(response => this._values.next(response));
+  }
+
+  public getValues(): SpaEnvResponse {
+    return this._values.getValue();
   }
 
   private loadEnvs(){


### PR DESCRIPTION
Since FPCare doesn't use an up-to-date version of the common library, I've left the `address-validator` component out of common library for now. Instead I've added it to the `core/components` folder within FPCare.

I'll be extracting the `address-validator` component and putting in the common library for other projects which are up to date.